### PR TITLE
reviews: Assign reviewers to all repos in the quilt organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-Quilt Bot
-=========
+# Quilt Bot
 
 Handles Code Review and Slack notifications.
+
+## Configuring The Code Review Webhook
+
+We use webhooks instead of polling to trigger review processing so that we don't
+get rate limited. A single webhook can be added to the entire organization, rather
+than to each individual repository.
+
+To configure:
+1. Boot the quilt-bot spec and note its public IP
+2. Navigate to your organization page (e.g. github.com/quilt)
+3. Click "Settings"
+4. Click "Webhooks"
+5. The "Secret" can be left blank as it is unused
+6. Enter `http://${QUILT_BOT_PUBLIC_IP}` under `Payload URL`
+7. Set the Webhook trigger to `Send me everything`
+8. Click "Add webhook"

--- a/bot.js
+++ b/bot.js
@@ -5,6 +5,7 @@ exports.New = function(slack_channel, slack_endpoint, github_oath) {
         "GITHUB_OATH": github_oath,
     })]);
 
+    publicInternet.connect(80, service);
     service.connect(80, publicInternet);
     service.connect(443, publicInternet);
     service.connect(53, publicInternet);

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
+	"golang.org/x/net/context"
 	"os"
 	"time"
 
@@ -22,7 +22,7 @@ func main() {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: os.Getenv("GITHUB_OATH")},
 	)
-	tc := oauth2.NewClient(context.Background(), ts)
+	tc := oauth2.NewClient(ctx(), ts)
 
 	client := github.NewClient(tc)
 
@@ -115,7 +115,7 @@ func getUsers(client *github.Client) ([]starGazer, error) {
 
 	opt := &github.ListOptions{}
 	for {
-		sgs, resp, err := client.Activity.ListStargazers("quilt", "quilt", opt)
+		sgs, resp, err := client.Activity.ListStargazers(ctx(), "quilt", "quilt", opt)
 		if err != nil {
 			return nil, err
 		}
@@ -134,4 +134,9 @@ func getUsers(client *github.Client) ([]starGazer, error) {
 	}
 
 	return results, nil
+}
+
+func ctx() context.Context {
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	return ctx
 }

--- a/review.go
+++ b/review.go
@@ -14,14 +14,14 @@ type review struct {
 }
 
 func runReview(client *github.Client) {
-	repos, _, err := client.Repositories.ListByOrg("quilt", nil)
+	repos, _, err := client.Repositories.ListByOrg(ctx(), "quilt", nil)
 	if err != nil {
 		fmt.Println("Failed to list repos: ", err)
 		return
 	}
 
 	for _, repo := range repos {
-		prs, _, err := client.PullRequests.List("quilt", *repo.Name, nil)
+		prs, _, err := client.PullRequests.List(ctx(), "quilt", *repo.Name, nil)
 		if err != nil {
 			fmt.Println("Failed to list pull requests: ", err)
 			return
@@ -147,7 +147,7 @@ func prRequest(client *github.Client, pr *github.PullRequest, method,
 	// This API isn't ready yet, so we have to disclaim with a magic header.
 	req.Header.Set("Accept", "application/vnd.github.black-cat-preview+json")
 
-	_, err = client.Do(req, result)
+	_, err = client.Do(ctx(), req, result)
 	return err
 }
 
@@ -163,7 +163,7 @@ func getTeamMembers(client *github.Client) (members, committers []string) {
 		}
 	}
 
-	teams, _, err := client.Organizations.ListTeams("quilt", nil)
+	teams, _, err := client.Organizations.ListTeams(ctx(), "quilt", nil)
 	if err != nil {
 		fmt.Println("Failed to list teams: ", err)
 		return cachedMembers, cachedCommitters
@@ -179,13 +179,13 @@ func getTeamMembers(client *github.Client) (members, committers []string) {
 		}
 	}
 
-	newMembers, _, err := client.Organizations.ListTeamMembers(memberID, nil)
+	newMembers, _, err := client.Organizations.ListTeamMembers(ctx(), memberID, nil)
 	if err != nil {
 		fmt.Println("Failed to list team members: ", err)
 		return cachedMembers, cachedCommitters
 	}
 
-	newCommitters, _, err := client.Organizations.ListTeamMembers(committerID, nil)
+	newCommitters, _, err := client.Organizations.ListTeamMembers(ctx(), committerID, nil)
 	if err != nil {
 		fmt.Println("Failed to list committers: ", err)
 		return cachedMembers, cachedCommitters


### PR DESCRIPTION
Now that each spec its own repository (e.g. `quilt/nginx`,
`quilt/haproxy`), assigning reviewers to only `quilt/quilt` is no longer
sufficient.