### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,3 +1,5 @@
+const {Container, Service, publicInternet} = require("@quilt/quilt");
+
 exports.New = function(slack_channel, slack_endpoint, github_oath) {
     service = new Service("bot", [new Container("quilt/bot").withEnv({
         "SLACK_CHANNEL": slack_channel,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@quilt/bot",
+  "version": "0.0.1",
+  "main": "./bot.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
+}


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.